### PR TITLE
Improve responsive layout and show timestamps

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -23,6 +23,10 @@ pub struct ConversationSummary {
     pub topic: String,
     #[serde(rename = "preview")]
     pub preview: String,
+    #[serde(rename = "lastDeliveredDateTime")]
+    pub last_delivered: Option<String>,
+    #[serde(rename = "uniqueSenders")]
+    pub unique_senders: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary
- adjust conversation data to include sender and time info
- render the sidebar using the pane width
- format dates in local timezone and show them in the sidebar
- resize the details view based on available space

## Testing
- `cargo build`